### PR TITLE
accept onprem as url

### DIFF
--- a/src/cell/carto.js
+++ b/src/cell/carto.js
@@ -124,7 +124,7 @@ export class CartoVisualizer extends React.Component {
                     label: 'Voyager'
                 }).addTo(map);
 
-                var layer = cartodb.createLayer(map, {
+                let layer_opts = {
                     user_name: config.credentials.user,
                     type: 'cartodb',
                     sublayers: [{
@@ -137,7 +137,14 @@ export class CartoVisualizer extends React.Component {
                     extra_params: {
                         map_key: config.credentials.apiKey
                     }
-                }, { https: true });
+                }
+
+                if (config.credentials.host.indexOf('carto.com') === -1) {
+                    layer_opts['sql_api_template'] = `https://${config.credentials.host}/user/{user}`;
+                    layer_opts['maps_api_template'] = `https://${config.credentials.host}/user/{user}`
+                }
+
+                var layer = cartodb.createLayer(map, layer_opts, { https: true });
 
                 layer
                     .addTo(map)
@@ -170,10 +177,18 @@ export class CartoVisualizer extends React.Component {
 
     zoomToLayer(layer, config) {
         var self = this;
-        let sql = new cartodb.SQL({
+        let sql_opts = {
             user: config.credentials.user,
             api_key: config.credentials.apiKey
-        });
+        };
+
+        if(config.credentials.host.indexOf('carto.com') === -1) {
+            sql_opts['sql_api_template'] = `https://${config.credentials.host}/user/{user}`
+            sql_opts['maps_api_template'] = `https://${config.credentials.host}/user/{user}`
+        }
+
+        let sql = new cartodb.SQL(sql_opts);
+
         sql.getBounds(
             layer.getQuery().replaceAll('{{', '').replaceAll('}}', '')
         ).done(function(bounds) {

--- a/src/db/carto.js
+++ b/src/db/carto.js
@@ -89,7 +89,18 @@ export function disconnectDB() {
 }
 
 export async function sendRequest(query) {
-  let response = await fetch('https://' + State.get('config', 'carto', 'credentials', 'user') + '.' + State.get('config', 'carto', 'credentials', 'host') + '/api/v1/sql?q=' + encodeURIComponent(query) + '&api_key=' + State.get('config', 'carto', 'credentials', 'apiKey'));
+  let sql_api_url;
+  const opts = {
+    'host': State.get('config', 'carto', 'credentials', 'host'),
+    'user': State.get('config', 'carto', 'credentials', 'user'),
+    'apiKey': State.get('config', 'carto', 'credentials', 'apiKey')
+  }
+  if (opts.host.indexOf('carto.com') > -1) {
+    sql_api_url = `https://${opts.user}.${opts.host}/api/v2/sql?q=${query}&api_key=${opts.apiKey}`
+  } else {
+    sql_api_url = `https://${opts.host}/user/${opts.user}/api/v2/sql?q=${query}&api_key=${opts.apiKey}`
+  }
+  let response = await fetch(sql_api_url);
 
   return await response.json();
 }


### PR DESCRIPTION
Accept OnPremise URLs as host name. Simply checks whether the host contains `carto.com` and, if not, modifies the SQL API structure and adds the `sql_api_template` and `maps_api_template` keys to the carto.js calls.